### PR TITLE
use ob_end_clean instead of ob_clean in order to prevent donwloading …

### DIFF
--- a/src/Concrete/Service/Excel/Export.php
+++ b/src/Concrete/Service/Excel/Export.php
@@ -49,7 +49,7 @@ class Export
      */
     public function download($fileName)
     {
-        ob_clean();
+        ob_end_clean();
         set_time_limit(0);
         $this->setFileProprietes();
 


### PR DESCRIPTION
…compressed xmlx files when zlib.output_compression is on